### PR TITLE
Extend solution with Blazor Shared Component Library Project

### DIFF
--- a/BlazorWasm.Shared/BlazorWasm.Shared.csproj
+++ b/BlazorWasm.Shared/BlazorWasm.Shared.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/BlazorWasm.Shared/Components/SharedComponent.razor
+++ b/BlazorWasm.Shared/Components/SharedComponent.razor
@@ -1,0 +1,14 @@
+@page "/shared-component"
+
+@using Microsoft.AspNetCore.Components
+
+<HeadContent>
+    <script src="shared.js"></script>
+</HeadContent>
+
+<h3>@Title</h3>
+
+@code {
+    [Parameter]
+    public string Title { get; set; }
+}

--- a/BlazorWasm.Shared/Components/SharedComponent.razor.cs
+++ b/BlazorWasm.Shared/Components/SharedComponent.razor.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorWasm.Shared.Components
+{
+    public partial class SharedComponent : ComponentBase
+    {
+        [Parameter]
+        public string Title { get; set; }
+    }
+}

--- a/BlazorWasm.sln
+++ b/BlazorWasm.sln
@@ -1,8 +1,9 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWasm", "BlazorWasm\BlazorWasm\BlazorWasm.csproj", "{F1E3902A-1E8B-451C-9230-3F9997AC964A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWasm.Client", "BlazorWasm\BlazorWasm.Client\BlazorWasm.Client.csproj", "{0C095DED-91B0-4E8E-8B62-2F65944889DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWasm.Shared", "BlazorWasm.Shared\BlazorWasm.Shared.csproj", "{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{F6A82598-6DB1-4097-94A5-624B1DFB0C16}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,5 +25,9 @@ Global
 		{0C095DED-91B0-4E8E-8B62-2F65944889DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C095DED-91B0-4E8E-8B62-2F65944889DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C095DED-91B0-4E8E-8B62-2F65944889DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/blogposts/blogpost_blazor_shared_component_library.md
+++ b/blogposts/blogpost_blazor_shared_component_library.md
@@ -1,0 +1,81 @@
+# Creating and Using a Blazor Shared Component Library
+
+In this blog post, we will walk through the process of creating a Blazor Shared Component Library Project, including shared JavaScript files using the `HeadContent` tag, and writing components with parameters. This guide will help you understand how to extend your Blazor solution with reusable components and shared resources.
+
+## Step-by-Step Guide on Creating a Blazor Shared Component Library Project
+
+1. **Create a New Blazor Shared Component Library Project**
+   - Open your solution in Visual Studio.
+   - Right-click on the solution and select `Add > New Project`.
+   - Choose `Blazor Component Library` and name it `BlazorWasm.Shared`.
+   - Set the `TargetFramework` to `net9.0` in the `BlazorWasm.Shared.csproj` file.
+
+2. **Add the New Project to the Solution**
+   - Open the `BlazorWasm.sln` file.
+   - Add the following entry to include the new project:
+     ```xml
+     Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWasm.Shared", "BlazorWasm.Shared\BlazorWasm.Shared.csproj", "{A1B2C3D4-E5F6-7890-1234-56789ABCDEF0}"
+     EndProject
+     ```
+
+## Including Shared JavaScript Files Using the `HeadContent` Tag
+
+To include shared JavaScript files in your Blazor components, you can use the `HeadContent` tag. This allows you to add scripts that will be included in the HTML head section when the component is rendered.
+
+### Example
+
+1. **Create a Shared Component**
+   - Add a new Razor component file named `SharedComponent.razor` in the `Components` folder of the `BlazorWasm.Shared` project.
+   - Include the `HeadContent` tag to reference a shared JavaScript file:
+     ```razor
+     @page "/shared-component"
+
+     @using Microsoft.AspNetCore.Components
+
+     <HeadContent>
+         <script src="shared.js"></script>
+     </HeadContent>
+
+     <h3>@Title</h3>
+
+     @code {
+         [Parameter]
+         public string Title { get; set; }
+     }
+     ```
+
+2. **Create the Code-Behind File**
+   - Add a code-behind file named `SharedComponent.razor.cs` to define the `Title` parameter:
+     ```csharp
+     using Microsoft.AspNetCore.Components;
+
+     namespace BlazorWasm.Shared.Components
+     {
+         public partial class SharedComponent : ComponentBase
+         {
+             [Parameter]
+             public string Title { get; set; }
+         }
+     }
+     ```
+
+## Writing Components with Parameters in the Shared Library
+
+Blazor components can accept parameters, allowing you to pass data to them when they are used. This makes the components more flexible and reusable.
+
+### Example
+
+1. **Define a Parameter in the Component**
+   - In the `SharedComponent.razor` file, we have already defined a `Title` parameter using the `[Parameter]` attribute.
+
+2. **Use the Component in Another Project**
+   - In your main Blazor project, you can now use the `SharedComponent` and pass a value to the `Title` parameter:
+     ```razor
+     @page "/example"
+
+     <h3>Example Page</h3>
+
+     <BlazorWasm.Shared.Components.SharedComponent Title="Hello from Shared Component!" />
+     ```
+
+By following these steps, you can create a Blazor Shared Component Library, include shared JavaScript files, and write components with parameters. This approach helps you build reusable and maintainable components that can be shared across different projects in your Blazor solution.


### PR DESCRIPTION
Fixes #1

Extend the solution with a Blazor Shared Component Library Project and include shared components.

* Add a new Blazor Shared Component Library Project `BlazorWasm.Shared` with `TargetFramework` set to `net9.0`.
* Create a shared component `SharedComponent.razor` with a `Title` parameter and include a shared JavaScript file using the `HeadContent` tag.
* Add a code-behind file `SharedComponent.razor.cs` to define the `Title` parameter.
* Update the solution file `BlazorWasm.sln` to include the new Blazor Shared Component Library Project.
* Add a new blog post file `blogposts/blogpost_blazor_shared_component_library.md` documenting the integrations and how to write a Blazor Shared Component Library.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/schroedermarius/medium-blazor-wasm/pull/2?shareId=a5d0a5cc-da33-49ce-a89c-9800469571c8).